### PR TITLE
composer.lockをignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ phpunit.xml
 .vagrant
 Vagrantfile
 .idea
+composer.lock
 
 app/config/core.php
 app/config/log/config.php


### PR DESCRIPTION
composer.lockは環境に依存するのでリポジトリに含めないようにしておく。
