### PR TITLE
layoutビューからのbootstrap css/js呼び出しで、パスにbootstrapを追記

### DIFF
--- a/app/views/layouts/default.php
+++ b/app/views/layouts/default.php
@@ -4,7 +4,7 @@
     <title><?php eh($title)?></title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->
-    <link href="css/bootstrap.min.css" rel="stylesheet">
+    <link href="bootstrap/css/bootstrap.min.css" rel="stylesheet">
 
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
@@ -22,6 +22,6 @@
 <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
 <script src="https://code.jquery.com/jquery.js"></script>
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="js/bootstrap.min.js"></script>
+<script src="bootstrap/js/bootstrap.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
次のようなログを出力していました。bootstrapのcssとjsファイルの呼び出し部分でwebroot直下のcss/jsを呼んでいましたので、bootstrapディレクトリを追記して解消しました

> PHP Warning:  require(sc_path//app/controllers/js_controller.php): failed to open stream: No such file or directory in sc_path/app/config/bootstrap.php on line 19,
> PHP Fatal error:  require(): Failed opening required 'sc_path//app/controllers/js_controller.php' (include_path='.:/usr/share/php:/usr/share/pear') in sc_path/app/config/bootstrap.php on line 19,
