### PR TITLE
fix DietCake\Dispatcher' not found error

### DIFF
--- a/app/config/bootstrap.php
+++ b/app/config/bootstrap.php
@@ -1,7 +1,4 @@
 <?php
-// autoload
-require_once VENDOR_DIR.'autoload.php';
-
 // application
 require_once APP_DIR.'app_controller.php';
 require_once APP_DIR.'app_model.php';

--- a/app/webroot/index.php
+++ b/app/webroot/index.php
@@ -11,6 +11,9 @@ if (php_sapi_name() === 'cli-server') {
     $_REQUEST['dc_action'] = preg_replace('/\A\//', '', $cli_filepath);
 }
 
+// autoload
+require_once ROOT_DIR.'vendor/autoload.php';
+
 require_once ROOT_DIR.'vendor/dietcake/dietcake/dietcake.php';
 require_once CONFIG_DIR.'bootstrap.php';
 require_once CONFIG_DIR.'core.php';


### PR DESCRIPTION
現状でdietcakeをv2に上げると [ここ](https://github.com/tsukimiya/spongecake/blob/master/app/webroot/index.php#L14) で下記のFatal errorエラーとなってしまいます。
```
Fatal error: Uncaught Error: Class 'DietCake\Dispatcher' not found
```

これはdietcakeのv2では名前空間が導入された関係で、autoloadが有効になっていないとsrc以下にあるDietCakeの名前空間下のDispatcherクラスの実体が解決できないためのようです。
dietcake側の該当箇所
https://github.com/dietcake/dietcake/blob/master/dietcake.php#L14

autoload を有効にするタイミングを調整してエラーが発生しないようにしました。